### PR TITLE
COOK Burn Wallet Designation

### DIFF
--- a/assets/833815143.json
+++ b/assets/833815143.json
@@ -1,0 +1,8 @@
+[
+  {
+    "address": CXPJBOGP3HGVH4S43QEFZUFTVCOENBROIH34TQMTZER4HS2LVFHODOPW4E ,
+    "type": "BURN",
+    "txid": Z2ZYPXD6TMFXVHY7ERYC4XBFDEIVRT7TO2322ILQSDCH24HT7VSQ,
+    "description": "This is the Burn Wallet for COOK tokens, tokens are sent to this address in every game interaction-- it has been rekeyed to a random adress: OVKASDIMHRMIGR2NBZWWM4HB5GGD2OPSHM24GRUQW3Z3J2BMFSGD5IXT6A" 
+  }
+]

--- a/assets/833815193.json
+++ b/assets/833815193.json
@@ -1,0 +1,8 @@
+[
+  {
+    "address": CXPJBOGP3HGVH4S43QEFZUFTVCOENBROIH34TQMTZER4HS2LVFHODOPW4E ,
+    "type": "BURN",
+    "txid": Z2ZYPXD6TMFXVHY7ERYC4XBFDEIVRT7TO2322ILQSDCH24HT7VSQ,
+    "description": "This is the Burn Wallet for COOK tokens, tokens are sent to this address in every game interaction-- it has been rekeyed to a random adress: OVKASDIMHRMIGR2NBZWWM4HB5GGD2OPSHM24GRUQW3Z3J2BMFSGD5IXT6A" 
+  }
+]


### PR DESCRIPTION
This .json contains the burn wallet address for COOK tokens, where all game interactions result in "burns" (asset transfers) to a rekeyed address, transaction ID for rekey is included.